### PR TITLE
Persist data in /config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY app app
-RUN mkdir /app/media
+RUN mkdir -p /config /ranker-media
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ Run the application:
 uvicorn app.main:app --reload
 ```
 
-The app serves files from a `media` directory. You should mount a folder from
-the host into `/app/media` when running the container. Users can register, log
-in and rate the displayed media from 1 to 5 using buttons or the keyboard.
+The app serves files from a `/ranker-media` directory. You should mount a
+folder from the host into this location when running the container. A SQLite
+database is stored under `/config`, so that directory should also be mounted to
+retain user accounts and ratings. Users can register, log in and rate the
+displayed media from 1 to 5 using buttons or the keyboard.
 
 ## Docker
 
@@ -26,7 +28,10 @@ Build and run with Docker:
 
 ```bash
 docker build -t ranker .
-docker run -p 8000:8000 -v /path/to/media:/app/media ranker
+docker run -p 8000:8000 \
+    -v /path/to/config:/config \
+    -v /path/to/media:/ranker-media \
+    ranker
 ```
 
 ## CI

--- a/app/main.py
+++ b/app/main.py
@@ -8,14 +8,17 @@ from fastapi.templating import Jinja2Templates
 
 app = FastAPI()
 
-# Ensure media directory exists even if mounted at runtime
-os.makedirs("media", exist_ok=True)
-app.mount("/media", StaticFiles(directory="media"), name="media")
+# Ensure directories exist even if mounted at runtime
+MEDIA_DIR = "/ranker-media"
+CONFIG_DIR = "/config"
+os.makedirs(MEDIA_DIR, exist_ok=True)
+os.makedirs(CONFIG_DIR, exist_ok=True)
+app.mount("/media", StaticFiles(directory=MEDIA_DIR), name="media")
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 
 templates = Jinja2Templates(directory="app/templates")
 
-DATABASE = "database.db"
+DATABASE = os.path.join(CONFIG_DIR, "database.db")
 
 
 def init_db():
@@ -48,7 +51,11 @@ def verify_user(username: str, password: str) -> bool:
 
 
 def get_media_file() -> str | None:
-    files = [f for f in os.listdir("media") if os.path.isfile(os.path.join("media", f))]
+    files = [
+        f
+        for f in os.listdir(MEDIA_DIR)
+        if os.path.isfile(os.path.join(MEDIA_DIR, f))
+    ]
     return sorted(files)[0] if files else None
 
 


### PR DESCRIPTION
## Summary
- configure media and config directories
- store database in /config
- document new container paths
- create /config and /ranker-media in the image

## Testing
- `pip install -r requirements.txt`
- `python3 -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6876be95ae60833081c6c9e705be6f7f