### PR TITLE
Add admin management

### DIFF
--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" href="/static/style.css" />
+</head>
+<body>
+<div class="container">
+<h1>Admin</h1>
+<h2>Users</h2>
+<ul>
+{% for user in users %}
+<li>{{user}}</li>
+{% endfor %}
+</ul>
+<h2>Reset Password</h2>
+<form method="post" action="/admin/reset-password">
+  <input type="text" name="username" placeholder="Username" />
+  <input type="password" name="new_password" placeholder="New Password" />
+  <input type="submit" value="Reset" />
+</form>
+<h2>Upload Media</h2>
+<form method="post" action="/admin/upload" enctype="multipart/form-data">
+  <input type="file" name="file" />
+  <input type="submit" value="Upload" />
+</form>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create an admin role and default admin account
- allow password resets and media upload on `/admin`

## Testing
- `python3 -m py_compile app/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876befff048833095a823c1b8fd7fd4