### PR TITLE
Add logout and username display

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -67,7 +67,10 @@ def index(request: Request):
     file_name = get_media_file()
     if not file_name:
         return HTMLResponse("No media files found", status_code=404)
-    return templates.TemplateResponse("index.html", {"request": request, "file": file_name})
+    return templates.TemplateResponse(
+        "index.html",
+        {"request": request, "file": file_name, "username": username},
+    )
 
 
 @app.post("/rate")
@@ -120,4 +123,12 @@ def register_post(username: str = Form(...), password: str = Form(...)):
         raise HTTPException(status_code=400, detail="Username exists")
     conn.close()
     return RedirectResponse("/login", status_code=303)
+
+
+@app.get("/logout")
+def logout():
+    """Clear the authentication cookie and redirect to the login page."""
+    response = RedirectResponse("/login")
+    response.delete_cookie("username")
+    return response
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -18,6 +18,7 @@ function rate(val) {
 </head>
 <body>
 <div class="container">
+<p>Logged in as {{username}} | <a class="link" href="/logout">Logout</a></p>
 <h1>Rate the media</h1>
 <img src="/media/{{file}}" alt="media" />
 <form id="rate-form" action="/rate" method="post">

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -7,8 +7,8 @@
 <div class="container">
 <h1>Login</h1>
 <form method="post">
-  <input type="text" name="username" placeholder="Username" />
-  <input type="password" name="password" placeholder="Password" />
+  <input type="text" id="username" name="username" placeholder="Username" autocomplete="username" required />
+  <input type="password" id="password" name="password" placeholder="Password" autocomplete="current-password" required />
   <input type="submit" value="Login" />
 </form>
 <a class="link" href="/register">Register</a>

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -7,8 +7,8 @@
 <div class="container">
 <h1>Register</h1>
 <form method="post">
-  <input type="text" name="username" placeholder="Username" />
-  <input type="password" name="password" placeholder="Password" />
+  <input type="text" id="username" name="username" placeholder="Username" autocomplete="username" required />
+  <input type="password" id="password" name="password" placeholder="Password" autocomplete="new-password" required />
   <input type="submit" value="Register" />
 </form>
 <a class="link" href="/login">Login</a>


### PR DESCRIPTION
## Summary
- show the logged in username and add a logout link
- pass username to template
- make login and register forms easier for password managers to recognize

## Testing
- `python -m py_compile app/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876c08a1a18833086dda1ac704503ab