### PR TITLE
Add admin management features

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ database is stored under `/config`, so that directory should also be mounted to
 retain user accounts and ratings. Users can register, log in and rate the
 displayed media from 1 to 5 using buttons or the keyboard.
 
+Admin usernames can be supplied via the `ADMIN_USERS` environment variable as a
+comma separated list. When set, an authenticated admin can visit `/admin` to
+manage accounts and upload new media files.
+
 ## Docker
 
 Build and run with Docker:
@@ -31,6 +35,7 @@ docker build -t ranker .
 docker run -p 8000:8000 \
     -v /path/to/config:/config \
     -v /path/to/media:/ranker-media \
+    -e ADMIN_USERS=admin1,admin2 \
     ranker
 ```
 

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" href="/static/style.css" />
+</head>
+<body>
+<div class="container">
+<p>Logged in as {{username}} | <a class="link" href="/logout">Logout</a></p>
+<h1>Admin Panel</h1>
+<h2>Users</h2>
+<ul>
+  {% for user in users %}
+    <li>{{ user }}</li>
+  {% endfor %}
+</ul>
+<h2>Change User Password</h2>
+<form method="post" action="/admin/change_password">
+  <select name="target_user">
+    {% for user in users %}
+    <option value="{{ user }}">{{ user }}</option>
+    {% endfor %}
+  </select>
+  <input type="password" name="new_password" placeholder="New password" required />
+  <input type="submit" value="Change Password" />
+</form>
+<h2>Upload Media</h2>
+<form method="post" action="/admin/upload_media" enctype="multipart/form-data">
+  <input type="file" name="media" required />
+  <input type="submit" value="Upload" />
+</form>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow admins via `ADMIN_USERS` env var
- add admin panel with password change and media upload
- document new admin workflow

## Testing
- `python -m py_compile app/main.py`
- `pip install -r requirements.txt`
- `python -m uvicorn app.main:app --host 0.0.0.0 --port 8001`

------
https://chatgpt.com/codex/tasks/task_e_6876c1cc64c483309e6a1c4dd25645c6