### PR TITLE
Add multi-file upload for admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ displayed media from 1 to 5 using buttons or the keyboard.
 
 Admin usernames can be supplied via the `ADMIN_USERS` environment variable as a
 comma separated list. When set, an authenticated admin can visit `/admin` to
-manage accounts and upload new media files.
+manage accounts and upload new media files. The upload form accepts multiple
+files so an admin can add several media items in one request.
 
 ## Docker
 

--- a/app/main.py
+++ b/app/main.py
@@ -189,13 +189,13 @@ def admin_change_password(
 @app.post("/admin/upload_media")
 def admin_upload_media(
     request: Request,
-    media: UploadFile = File(...),
+    media_files: list[UploadFile] = File(...),
 ):
     username = request.cookies.get("username")
     if not is_admin(username):
         return RedirectResponse("/login")
-    file_path = os.path.join(MEDIA_DIR, media.filename)
-    with open(file_path, "wb") as f:
-        f.write(media.file.read())
+    for media_file in media_files:
+        file_path = os.path.join(MEDIA_DIR, media_file.filename)
+        with open(file_path, "wb") as f:
+            f.write(media_file.file.read())
     return RedirectResponse("/admin", status_code=303)
-

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -25,7 +25,7 @@
 </form>
 <h2>Upload Media</h2>
 <form method="post" action="/admin/upload_media" enctype="multipart/form-data">
-  <input type="file" name="media" required />
+  <input type="file" name="media_files" multiple required />
   <input type="submit" value="Upload" />
 </form>
 </div>


### PR DESCRIPTION
## Summary
- allow uploading multiple files from the admin panel
- update the form in `admin.html` to allow multi-file select
- document multi-file uploads in README

## Testing
- `python -m py_compile app/main.py`
- `flake8 app/main.py` *(fails: line too long)*

------
https://chatgpt.com/codex/tasks/task_e_6876c3ff1588833081a1ac956a3339af