### PR TITLE
Add admin link and show logout info always

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -93,11 +93,15 @@ def index(request: Request):
     if not username:
         return RedirectResponse("/login")
     file_name = get_media_file()
-    if not file_name:
-        return HTMLResponse("No media files found", status_code=404)
     return templates.TemplateResponse(
         "index.html",
-        {"request": request, "file": file_name, "username": username},
+        {
+            "request": request,
+            "file": file_name,
+            "username": username,
+            "is_admin": is_admin(username),
+        },
+        status_code=200 if file_name else 404,
     )
 
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -18,8 +18,13 @@ function rate(val) {
 </head>
 <body>
 <div class="container">
-<p>Logged in as {{username}} | <a class="link" href="/logout">Logout</a></p>
+<p>
+  Logged in as {{username}} |
+  <a class="link" href="/logout">Logout</a>
+  {% if is_admin %}| <a class="link" href="/admin">Admin</a>{% endif %}
+</p>
 <h1>Rate the media</h1>
+{% if file %}
 <img src="/media/{{file}}" alt="media" />
 <form id="rate-form" action="/rate" method="post">
   <input type="hidden" id="file" name="file" value="{{file}}" />
@@ -28,6 +33,9 @@ function rate(val) {
     <button type="button" onclick="rate({{i}})">{{i}}</button>
   {% endfor %}
 </form>
+{% else %}
+<p>No media files found</p>
+{% endif %}
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show login info even if no media available
- show link to admin page when logged in as admin
- keep `/` page visible even when there are no media files

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6876c44abfbc8330ac9f940ca57fed3a