### PR TITLE
Improve layout with reusable template

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -100,6 +100,10 @@ def index(request: Request):
             "file": file_name,
             "username": username,
             "is_admin": is_admin(username),
+            "show_admin": is_admin(username),
+            "show_back": False,
+            "body_class": None,
+            "container_class": None,
         },
         status_code=200 if file_name else 404,
     )
@@ -123,7 +127,17 @@ def rate(request: Request, file: str = Form(...), score: int = Form(...)):
 
 @app.get("/login", response_class=HTMLResponse)
 def login_get(request: Request):
-    return templates.TemplateResponse("login.html", {"request": request})
+    return templates.TemplateResponse(
+        "login.html",
+        {
+            "request": request,
+            "username": None,
+            "body_class": None,
+            "container_class": None,
+            "show_admin": False,
+            "show_back": False,
+        },
+    )
 
 
 @app.post("/login")
@@ -137,7 +151,17 @@ def login_post(username: str = Form(...), password: str = Form(...)):
 
 @app.get("/register", response_class=HTMLResponse)
 def register_get(request: Request):
-    return templates.TemplateResponse("register.html", {"request": request})
+    return templates.TemplateResponse(
+        "register.html",
+        {
+            "request": request,
+            "username": None,
+            "body_class": None,
+            "container_class": None,
+            "show_admin": False,
+            "show_back": False,
+        },
+    )
 
 
 @app.post("/register")
@@ -173,7 +197,15 @@ def admin_panel(request: Request):
     users = list_users()
     return templates.TemplateResponse(
         "admin.html",
-        {"request": request, "username": username, "users": users},
+        {
+            "request": request,
+            "username": username,
+            "users": users,
+            "show_back": True,
+            "show_admin": False,
+            "body_class": "admin-page",
+            "container_class": "admin-container",
+        },
     )
 
 

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -9,12 +9,22 @@ body {
   min-height: 100vh;
 }
 
+body.admin-page {
+  align-items: flex-start;
+}
+
 .container {
   background: white;
   padding: 2rem;
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);
   border-radius: 4px;
   text-align: center;
+}
+
+.admin-container {
+  text-align: left;
+  width: 100%;
+  max-width: 600px;
 }
 
 h1 {
@@ -49,6 +59,24 @@ img {
   max-width: 100%;
   height: auto;
   margin-bottom: 1rem;
+}
+
+.media-preview {
+  max-height: 60vh;
+  object-fit: contain;
+}
+
+.header {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.username {
+  font-weight: bold;
+  margin-right: auto;
 }
 
 .link {

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -1,12 +1,6 @@
-<!DOCTYPE html>
-<html>
-<head>
-<link rel="stylesheet" href="/static/style.css" />
-</head>
-<body>
-<div class="container">
-<p>Logged in as {{username}} | <a class="link" href="/logout">Logout</a></p>
-<h1>Admin Panel</h1>
+{% extends "base.html" %}
+{% block title %}Admin{% endblock %}
+{% block content %}
 <h2>Users</h2>
 <ul>
   {% for user in users %}
@@ -28,6 +22,4 @@
   <input type="file" name="media_files" multiple required />
   <input type="submit" value="Upload" />
 </form>
-</div>
-</body>
-</html>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" href="/static/style.css" />
+<title>{% block title %}Ranker{% endblock %}</title>
+</head>
+<body{% if body_class %} class="{{ body_class }}"{% endif %}>
+<div class="container{% if container_class %} {{ container_class }}{% endif %}">
+{% if username %}
+  <div class="header">
+    <span class="username">{{ username }}</span>
+    {% if show_admin %}
+    <form method="get" action="/admin">
+      <button type="submit">Admin</button>
+    </form>
+    {% endif %}
+    {% if show_back %}
+    <form method="get" action="/">
+      <button type="submit">Back to Ranking</button>
+    </form>
+    {% endif %}
+    <form method="get" action="/logout">
+      <button type="submit">Logout</button>
+    </form>
+  </div>
+{% endif %}
+{% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,7 +1,18 @@
-<!DOCTYPE html>
-<html>
-<head>
-<link rel="stylesheet" href="/static/style.css" />
+{% extends "base.html" %}
+{% block title %}Rank Media{% endblock %}
+{% block content %}
+{% if file %}
+<img class="media-preview" src="/media/{{file}}" alt="media" />
+<form id="rate-form" action="/rate" method="post">
+  <input type="hidden" id="file" name="file" value="{{file}}" />
+  <input type="hidden" id="score" name="score" />
+  {% for i in range(1,6) %}
+    <button type="button" onclick="rate({{i}})">{{i}}</button>
+  {% endfor %}
+</form>
+{% else %}
+<p>No media files found</p>
+{% endif %}
 <script>
 document.addEventListener('keydown', function(e) {
   const key = e.key;
@@ -15,27 +26,4 @@ function rate(val) {
   document.getElementById('rate-form').submit();
 }
 </script>
-</head>
-<body>
-<div class="container">
-<p>
-  Logged in as {{username}} |
-  <a class="link" href="/logout">Logout</a>
-  {% if is_admin %}| <a class="link" href="/admin">Admin</a>{% endif %}
-</p>
-<h1>Rate the media</h1>
-{% if file %}
-<img src="/media/{{file}}" alt="media" />
-<form id="rate-form" action="/rate" method="post">
-  <input type="hidden" id="file" name="file" value="{{file}}" />
-  <input type="hidden" id="score" name="score" />
-  {% for i in range(1,6) %}
-    <button type="button" onclick="rate({{i}})">{{i}}</button>
-  {% endfor %}
-</form>
-{% else %}
-<p>No media files found</p>
-{% endif %}
-</div>
-</body>
-</html>
+{% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,10 +1,6 @@
-<!DOCTYPE html>
-<html>
-<head>
-<link rel="stylesheet" href="/static/style.css" />
-</head>
-<body>
-<div class="container">
+{% extends "base.html" %}
+{% block title %}Login{% endblock %}
+{% block content %}
 <h1>Login</h1>
 <form method="post">
   <input type="text" id="username" name="username" placeholder="Username" autocomplete="username" required />
@@ -12,6 +8,4 @@
   <input type="submit" value="Login" />
 </form>
 <a class="link" href="/register">Register</a>
-</div>
-</body>
-</html>
+{% endblock %}

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,10 +1,6 @@
-<!DOCTYPE html>
-<html>
-<head>
-<link rel="stylesheet" href="/static/style.css" />
-</head>
-<body>
-<div class="container">
+{% extends "base.html" %}
+{% block title %}Register{% endblock %}
+{% block content %}
 <h1>Register</h1>
 <form method="post">
   <input type="text" id="username" name="username" placeholder="Username" autocomplete="username" required />
@@ -12,6 +8,4 @@
   <input type="submit" value="Register" />
 </form>
 <a class="link" href="/login">Login</a>
-</div>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create a base template for reusability
- refactor index/admin/login/register pages to extend base
- style header, username and media sizing
- tweak admin page layout

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6876c684b818833081f4546a120c2119