### PR TITLE
Show last ranked timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ displayed media from 1 to 5 using buttons or the keyboard. Media items are
 presented in order of least recently rated for each user, so once an item is
 scored a different file will be shown next. Each rating stores the time it was
 submitted so files can be sorted by when a user last rated them.
+The page also displays when the current media was last rated by the user. If it
+was rated today, the timestamp appears in green.
 
 Admin usernames can be supplied via the `ADMIN_USERS` environment variable as a
 comma separated list. When set, an authenticated admin can visit `/admin` to

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -61,6 +61,23 @@ img {
   margin-bottom: 1rem;
 }
 
+.media-container {
+  position: relative;
+  display: inline-block;
+}
+
+.last-ranked {
+  position: absolute;
+  bottom: 0.25rem;
+  right: 0.25rem;
+  font-size: 0.8rem;
+  color: #555;
+}
+
+.last-ranked.today {
+  color: green;
+}
+
 .media-preview {
   max-height: 60vh;
   object-fit: contain;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,7 +2,12 @@
 {% block title %}Rank Media{% endblock %}
 {% block content %}
 {% if file %}
-<img class="media-preview" src="/media/{{file}}" alt="media" />
+<div class="media-container">
+  <img class="media-preview" src="/media/{{file}}" alt="media" />
+  {% if last_ranked %}
+  <span class="last-ranked{% if last_ranked_today %} today{% endif %}">last ranked: {{ last_ranked }}</span>
+  {% endif %}
+</div>
 <form id="rate-form" action="/rate" method="post">
   <input type="hidden" id="file" name="file" value="{{file}}" />
   <input type="hidden" id="score" name="score" />


### PR DESCRIPTION
## Summary
- show when a media item was last ranked
- highlight today's ranking in green

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6876c8f63bac8330b27d5c3c13439c63