### PR TITLE
Add build number display

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image
         run: |
-          docker build -t ghcr.io/${{ github.repository }}:latest .
+          docker build \
+            --build-arg BUILD_NUMBER=${{ github.run_number }} \
+            -t ghcr.io/${{ github.repository }}:latest .
       - name: Push image
         run: |
           docker push ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3.10-slim
+ARG BUILD_NUMBER=dev
+ENV BUILD_NUMBER=$BUILD_NUMBER
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/app/main.py
+++ b/app/main.py
@@ -23,6 +23,8 @@ ADMIN_USERS = {
     u.strip() for u in os.environ.get("ADMIN_USERS", "").split(",") if u.strip()
 }
 
+BUILD_NUMBER = os.environ.get("BUILD_NUMBER", "dev")
+
 DATABASE = os.path.join(CONFIG_DIR, "database.db")
 
 
@@ -226,6 +228,7 @@ def admin_panel(request: Request):
             "request": request,
             "username": username,
             "users": users,
+            "build_number": BUILD_NUMBER,
             "show_back": True,
             "show_admin": False,
             "body_class": "admin-page",

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -87,3 +87,9 @@ img {
 .link:hover {
   text-decoration: underline;
 }
+
+.build-info {
+  margin-top: 1rem;
+  font-size: 0.9rem;
+  color: #666;
+}

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -22,4 +22,5 @@
   <input type="file" name="media_files" multiple required />
   <input type="submit" value="Upload" />
 </form>
+<p class="build-info">Build {{ build_number }}</p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- inject build number via build arg
- surface build number in admin panel
- show build number when building the Docker image
- style build number text

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6876c9df519883309bd16619bd5c56db