### PR TITLE
Add statistics page and mobile tweaks

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -19,6 +19,8 @@ body.admin-page {
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);
   border-radius: 4px;
   text-align: center;
+  width: 100%;
+  max-width: 600px;
 }
 
 .admin-container {
@@ -70,7 +72,7 @@ img {
   position: absolute;
   bottom: 0.25rem;
   right: 0.25rem;
-  font-size: 0.8rem;
+  font-size: 1rem;
   color: #555;
 }
 
@@ -109,4 +111,27 @@ img {
   margin-top: 1rem;
   font-size: 0.9rem;
   color: #666;
+}
+
+#rate-form button {
+  font-size: 1.25rem;
+  padding: 0.75rem 1.25rem;
+}
+
+@media (max-width: 600px) {
+  .container {
+    padding: 1rem;
+    box-shadow: none;
+    border-radius: 0;
+  }
+  .admin-container {
+    width: 100%;
+  }
+  .media-preview {
+    max-height: 70vh;
+  }
+  #rate-form button {
+    font-size: 1.5rem;
+    padding: 1rem;
+  }
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -14,6 +14,9 @@
       <button type="submit">Admin</button>
     </form>
     {% endif %}
+    <form method="get" action="/stats">
+      <button type="submit">Stats</button>
+    </form>
     {% if show_back %}
     <form method="get" action="/">
       <button type="submit">Back to Ranking</button>

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block title %}Statistics{% endblock %}
+{% block content %}
+<h2>Top Rated Media</h2>
+{% if highest %}
+<ul>
+  {% for media, score in highest %}
+  <li>{{ media }} - {{ '%.2f' % score }}</li>
+  {% endfor %}
+</ul>
+{% else %}
+<p>No ratings yet.</p>
+{% endif %}
+<h2>Lowest Rated Media</h2>
+{% if lowest %}
+<ul>
+  {% for media, score in lowest %}
+  <li>{{ media }} - {{ '%.2f' % score }}</li>
+  {% endfor %}
+</ul>
+{% else %}
+<p>No ratings yet.</p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `Stats` link in header and new statistics template
- compute highest and lowest rated media and show them on `/stats`
- keep month capitalization for last ranked text
- enlarge last ranked text and rating buttons
- make containers responsive on mobile

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876ccc6b1d88330a8391800fbc115ee