### PR TITLE
Support ranking multiple images with ELO

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -66,6 +66,21 @@ img {
 .media-container {
   position: relative;
   display: inline-block;
+  flex: 1 1 calc(45% - 1rem);
+}
+
+.media-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.medal {
+  position: absolute;
+  top: 0.25rem;
+  left: 0.25rem;
+  font-size: 2rem;
 }
 
 .last-ranked {
@@ -83,6 +98,7 @@ img {
 .media-preview {
   max-height: 60vh;
   object-fit: contain;
+  width: 100%;
 }
 
 .header {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -14,9 +14,11 @@
       <button type="submit">Admin</button>
     </form>
     {% endif %}
+    {% if show_stats_link %}
     <form method="get" action="/stats">
       <button type="submit">Stats</button>
     </form>
+    {% endif %}
     {% if show_back %}
     <form method="get" action="/">
       <button type="submit">Back to Ranking</button>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,34 +1,52 @@
 {% extends "base.html" %}
 {% block title %}Rank Media{% endblock %}
 {% block content %}
-{% if file %}
-<div class="media-container">
-  <img class="media-preview" src="/media/{{file}}" alt="media" />
-  {% if last_ranked %}
-  <span class="last-ranked{% if last_ranked_today %} today{% endif %}">last ranked: {{ last_ranked }}</span>
-  {% endif %}
+{% if files %}
+<div class="media-grid">
+  {% for f in files %}
+  <div class="media-container" data-file="{{ f }}" onclick="toggleRank(this)">
+    <img class="media-preview" src="/media/{{ f }}" alt="{{ f }}" />
+    <span class="medal"></span>
+  </div>
+  {% endfor %}
 </div>
 <form id="rate-form" action="/rate" method="post">
-  <input type="hidden" id="file" name="file" value="{{file}}" />
-  <input type="hidden" id="score" name="score" />
-  {% for i in range(1,6) %}
-    <button type="button" onclick="rate({{i}})">{{i}}</button>
-  {% endfor %}
+  <input type="hidden" id="order" name="order" />
+  <button id="submit-btn" type="submit" style="display:none;">Submit</button>
 </form>
 {% else %}
 <p>No media files found</p>
 {% endif %}
 <script>
-document.addEventListener('keydown', function(e) {
-  const key = e.key;
-  if (['1','2','3','4','5'].includes(key)) {
-    document.getElementById('score').value = key;
-    document.getElementById('rate-form').submit();
+let selected = [];
+const maxRank = 3;
+function toggleRank(el){
+  const file = el.dataset.file;
+  const idx = selected.indexOf(file);
+  if(idx >= 0){
+    selected.splice(idx,1);
+  } else if(selected.length < maxRank){
+    selected.push(file);
   }
-});
-function rate(val) {
-  document.getElementById('score').value = val;
-  document.getElementById('rate-form').submit();
+  update();
+}
+function update(){
+  document.querySelectorAll('.media-container').forEach(c=>{
+    const medal = c.querySelector('.medal');
+    const idx = selected.indexOf(c.dataset.file);
+    medal.textContent = '';
+    medal.className = 'medal';
+    if(idx === 0){ medal.textContent='🥇'; }
+    else if(idx === 1){ medal.textContent='🥈'; }
+    else if(idx === 2){ medal.textContent='🥉'; }
+  });
+  let order = [...selected];
+  document.querySelectorAll('.media-container').forEach(c=>{
+    if(!order.includes(c.dataset.file)) order.push(c.dataset.file);
+  });
+  document.getElementById('order').value = order.join(',');
+  document.getElementById('submit-btn').style.display =
+      selected.length >= maxRank ? 'inline-block' : 'none';
 }
 </script>
 {% endblock %}

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -1,6 +1,22 @@
 {% extends "base.html" %}
 {% block title %}Statistics{% endblock %}
 {% block content %}
+<h2>Global ELO Ranking</h2>
+{% if elo_ranking %}
+<table class="stats-table">
+  <tr><th>#</th><th>Preview</th><th>Media</th><th>ELO</th></tr>
+  {% for idx, (media, elo) in enumerate(elo_ranking, start=1) %}
+  <tr>
+    <td>{{ idx }}</td>
+    <td><img class="thumbnail" src="/media/{{ media }}" alt="{{ media }}" /></td>
+    <td>{{ media }}</td>
+    <td>{{ '%.1f' % elo }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{% else %}
+<p>No rankings yet.</p>
+{% endif %}
 <h2>Your Highest Rated Media</h2>
 {% if user_highest %}
 <table class="stats-table">


### PR DESCRIPTION
## Summary
- allow ranking several images at once
- store order and update ELO ratings
- show medal overlays while ranking
- add global ELO ranking table
- hide stats link while viewing stats page

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6876d19be3f483309fba5338e4f82d5c