### PR TITLE
Fix media grid layout

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -70,7 +70,7 @@ img {
 .media-grid {
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(2, 1fr);
 }
 
 .medal {


### PR DESCRIPTION
## Summary
- keep image container with two columns instead of auto fitting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876e0019ea08330b2dd3fb92c165966