### PR TITLE
Add admin stats and user deletion

### DIFF
--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -2,11 +2,21 @@
 {% block title %}Admin{% endblock %}
 {% block content %}
 <h2>Users</h2>
-<ul>
+<table class="stats-table">
+  <tr><th>User</th><th>Rankings</th><th>Actions</th></tr>
   {% for user in users %}
-    <li>{{ user }}</li>
+  <tr>
+    <td>{{ user }}</td>
+    <td>{{ rating_counts.get(user, 0) }}</td>
+    <td>
+      <form method="post" action="/admin/delete_user" onsubmit="return confirm('Delete user and all data?');">
+        <input type="hidden" name="target_user" value="{{ user }}" />
+        <button type="submit">Delete</button>
+      </form>
+    </td>
+  </tr>
   {% endfor %}
-</ul>
+</table>
 <h2>Change User Password</h2>
 <form method="post" action="/admin/change_password">
   <select name="target_user">


### PR DESCRIPTION
## Summary
- show ranking counts per user on the admin page
- allow admins to delete a user and their data

## Testing
- `python -m py_compile app/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876e3150f948330bef743ea0b2ea16a