### PR TITLE
Add media summary to admin and stats pages

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -152,6 +152,26 @@ def change_user_password(username: str, new_password: str) -> None:
     conn.close()
 
 
+def get_user_rating_counts() -> dict[str, int]:
+    """Return number of rating entries for each user."""
+    conn = sqlite3.connect(DATABASE)
+    cur = conn.cursor()
+    cur.execute("SELECT username, COUNT(*) FROM ratings GROUP BY username")
+    rows = cur.fetchall()
+    conn.close()
+    return {row[0]: row[1] for row in rows}
+
+
+def delete_user(username: str) -> None:
+    """Remove a user and all of their rating data."""
+    conn = sqlite3.connect(DATABASE)
+    cur = conn.cursor()
+    cur.execute("DELETE FROM users WHERE username=?", (username,))
+    cur.execute("DELETE FROM ratings WHERE username=?", (username,))
+    conn.commit()
+    conn.close()
+
+
 def get_media_stats(limit: int = 5) -> tuple[list[tuple[str, float]], list[tuple[str, float]]]:
     conn = sqlite3.connect(DATABASE)
     cur = conn.cursor()
@@ -389,6 +409,7 @@ def admin_panel(request: Request):
     if not is_admin(username):
         return RedirectResponse("/login")
     users = list_users()
+    rating_counts = get_user_rating_counts()
     media_total, media_counts = get_media_file_summary()
     return templates.TemplateResponse(
         "admin.html",
@@ -396,6 +417,7 @@ def admin_panel(request: Request):
             "request": request,
             "username": username,
             "users": users,
+            "rating_counts": rating_counts,
             "media_total": media_total,
             "media_counts": media_counts,
             "build_number": BUILD_NUMBER,
@@ -418,6 +440,16 @@ def admin_change_password(
     if not is_admin(username):
         return RedirectResponse("/login")
     change_user_password(target_user, new_password)
+    return RedirectResponse("/admin", status_code=303)
+
+
+@app.post("/admin/delete_user")
+def admin_delete_user(request: Request, target_user: str = Form(...)):
+    """Delete a user account and all related ratings."""
+    username = request.cookies.get("username")
+    if not is_admin(username):
+        return RedirectResponse("/login")
+    delete_user(target_user)
     return RedirectResponse("/admin", status_code=303)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -82,6 +82,25 @@ def list_users() -> list[str]:
     return rows
 
 
+def get_media_file_summary() -> tuple[int, list[tuple[str, int]]]:
+    """Return total media count and counts by normalized name."""
+    files = [
+        f
+        for f in os.listdir(MEDIA_DIR)
+        if os.path.isfile(os.path.join(MEDIA_DIR, f))
+    ]
+    total = len(files)
+    counts: dict[str, int] = {}
+    for f in files:
+        name, _ = os.path.splitext(f)
+        name = name.lower()
+        name = name.replace("_", "")
+        name = "".join(ch for ch in name if not ch.isdigit())
+        counts[name] = counts.get(name, 0) + 1
+    sorted_counts = sorted(counts.items(), key=lambda x: (-x[1], x[0]))
+    return total, sorted_counts
+
+
 def get_media_files(username: str, count: int) -> list[str]:
     files = [
         f
@@ -342,6 +361,7 @@ def stats(request: Request):
     global_highest, global_lowest = get_global_media_stats_with_user(username)
     user_highest, user_lowest = get_user_media_stats(username)
     elo_ranking = get_elo_rankings()
+    media_total, media_counts = get_media_file_summary()
     return templates.TemplateResponse(
         "stats.html",
         {
@@ -352,6 +372,8 @@ def stats(request: Request):
             "user_highest": user_highest,
             "user_lowest": user_lowest,
             "elo_ranking": elo_ranking,
+            "media_total": media_total,
+            "media_counts": media_counts,
             "show_back": True,
             "show_admin": is_admin(username),
             "show_stats_link": False,
@@ -367,12 +389,15 @@ def admin_panel(request: Request):
     if not is_admin(username):
         return RedirectResponse("/login")
     users = list_users()
+    media_total, media_counts = get_media_file_summary()
     return templates.TemplateResponse(
         "admin.html",
         {
             "request": request,
             "username": username,
             "users": users,
+            "media_total": media_total,
+            "media_counts": media_counts,
             "build_number": BUILD_NUMBER,
             "show_back": True,
             "show_admin": False,

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -39,4 +39,11 @@ form.addEventListener('submit', async (e) => {
 });
 </script>
 <p class="build-info">Build {{ build_number }}</p>
+<h2>Media Summary</h2>
+<p>Total files: {{ media_total }}</p>
+<ul>
+  {% for name, count in media_counts %}
+  <li>{{ name }}: {{ count }}</li>
+  {% endfor %}
+</ul>
 {% endblock %}

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -2,11 +2,21 @@
 {% block title %}Admin{% endblock %}
 {% block content %}
 <h2>Users</h2>
-<ul>
+<table class="stats-table">
+  <tr><th>User</th><th>Rankings</th><th>Actions</th></tr>
   {% for user in users %}
-    <li>{{ user }}</li>
+  <tr>
+    <td>{{ user }}</td>
+    <td>{{ rating_counts.get(user, 0) }}</td>
+    <td>
+      <form method="post" action="/admin/delete_user" onsubmit="return confirm('Delete user and all data?');">
+        <input type="hidden" name="target_user" value="{{ user }}" />
+        <button type="submit">Delete</button>
+      </form>
+    </td>
+  </tr>
   {% endfor %}
-</ul>
+</table>
 <h2>Change User Password</h2>
 <form method="post" action="/admin/change_password">
   <select name="target_user">

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -84,4 +84,12 @@
 {% else %}
 <p>No ratings yet.</p>
 {% endif %}
+
+<h2>Media Summary</h2>
+<p>Total files: {{ media_total }}</p>
+<ul>
+  {% for name, count in media_counts %}
+  <li>{{ name }}: {{ count }}</li>
+  {% endfor %}
+</ul>
 {% endblock %}


### PR DESCRIPTION
## Summary
- compute counts for all files under `/ranker-media`
- show total media files and per-name counts on the admin page
- display the same summary at the bottom of the statistics page

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6876e3df40ec8330a6a420d774d7bedb