### PR TITLE
Add duplicate image removal

### DIFF
--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -32,6 +32,10 @@
   <input type="file" name="media_files" multiple required />
   <input type="submit" value="Upload" />
 </form>
+<h2>Remove Duplicate Images</h2>
+<form method="post" action="/admin/remove_duplicates" onsubmit="return confirm('Remove duplicate images?');">
+  <button type="submit">Remove Duplicates</button>
+</form>
 <script>
 const form = document.getElementById('upload-form');
 form.addEventListener('submit', async (e) => {

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 Jinja2
 python-multipart
+Pillow


### PR DESCRIPTION
## Summary
- add Pillow to requirements for image processing
- add logic to remove duplicate images in admin view
- expose `/admin/remove_duplicates` endpoint
- add button to trigger duplicate removal from admin page

## Testing
- `python -m py_compile app/main.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6876e46353b8833080512806a7ae3d4f