### PR TITLE
Improve ranking UI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -29,8 +29,8 @@ ADMIN_USERS = {
 
 BUILD_NUMBER = os.environ.get("BUILD_NUMBER", "dev")
 
-# Number of media items to display per ranking round
-NUM_MEDIA = int(os.environ.get("NUM_MEDIA", 4))
+# Number of media items to display per ranking round (fixed)
+NUM_MEDIA = 4
 
 DATABASE = os.path.join(CONFIG_DIR, "database.db")
 

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -95,7 +95,7 @@ img {
 .media-preview {
   width: 100%;
   height: 100%;
-  object-fit: contain;
+  object-fit: cover;
 }
 
 .header {
@@ -131,6 +131,10 @@ img {
   padding: 0.75rem 1.25rem;
 }
 
+#rate-form {
+  margin-top: 1rem;
+}
+
 @media (max-width: 600px) {
   .container {
     padding: 1rem;
@@ -146,6 +150,9 @@ img {
   #rate-form button {
     font-size: 1.5rem;
     padding: 1rem;
+  }
+  #rate-form {
+    margin-top: 1rem;
   }
 }
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -19,13 +19,13 @@
 {% endif %}
 <script>
 let selected = [];
-const maxRank = 3;
+const MAX_RANK = 4;
 function toggleRank(el){
   const file = el.dataset.file;
   const idx = selected.indexOf(file);
   if(idx >= 0){
     selected.splice(idx,1);
-  } else if(selected.length < maxRank){
+  } else if(selected.length < MAX_RANK){
     selected.push(file);
   }
   update();
@@ -46,7 +46,14 @@ function update(){
   });
   document.getElementById('order').value = order.join(',');
   document.getElementById('submit-btn').style.display =
-      selected.length >= maxRank ? 'inline-block' : 'none';
+      selected.length >= MAX_RANK ? 'inline-block' : 'none';
 }
+document.addEventListener('keydown', e => {
+  const n = parseInt(e.key);
+  if(n >= 1 && n <= 4){
+    const containers = document.querySelectorAll('.media-container');
+    if(containers[n-1]) toggleRank(containers[n-1]);
+  }
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- make number of media items fixed at 4
- use `object-fit: cover` so images fill their cell
- give submit button breathing room
- allow keyboard shortcuts 1–4 to select images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876e7b9e72c83309595b65e33f3a932