### PR TITLE
Show disabled submit button

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -43,6 +43,13 @@ button:hover, input[type="submit"]:hover {
   background-color: #45a049;
 }
 
+button:disabled,
+input[type="submit"]:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 input[type="text"],
 input[type="password"] {
   width: 100%;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,7 +12,7 @@
 </div>
 <form id="rate-form" action="/rate" method="post">
   <input type="hidden" id="order" name="order" />
-  <button id="submit-btn" type="submit" style="display:none;">Submit</button>
+  <button id="submit-btn" type="submit" disabled>Submit</button>
 </form>
 {% else %}
 <p>No media files found</p>
@@ -45,8 +45,7 @@ function update(){
     if(!order.includes(c.dataset.file)) order.push(c.dataset.file);
   });
   document.getElementById('order').value = order.join(',');
-  document.getElementById('submit-btn').style.display =
-      selected.length >= MAX_RANK ? 'inline-block' : 'none';
+  document.getElementById('submit-btn').disabled = selected.length < MAX_RANK;
 }
 document.addEventListener('keydown', e => {
   const n = parseInt(e.key);


### PR DESCRIPTION
## Summary
- keep submit button visible
- disable button until ranking complete
- style disabled buttons

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876e917f4f08330b79cb59747b390bb