### PR TITLE
Fix submit button overlay and ranking requirement

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -72,6 +72,7 @@ img {
   align-items: center;
   aspect-ratio: 4 / 3;
   width: 100%;
+  overflow: hidden;
 }
 
 .media-grid {
@@ -103,6 +104,7 @@ img {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  margin-bottom: 0;
 }
 
 .header {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -19,7 +19,7 @@
 {% endif %}
 <script>
 let selected = [];
-const MAX_RANK = 4;
+const MAX_RANK = 3;
 function toggleRank(el){
   const file = el.dataset.file;
   const idx = selected.indexOf(file);


### PR DESCRIPTION
## Summary
- keep media in its box and allow room for the submit button
- only require three selections when ranking media

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687706aab7c48330bccae1434a00c1a9