### PR TITLE
Add ELO group stats and layout improvements

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2,7 +2,8 @@ body {
   font-family: Arial, sans-serif;
   background-color: #f4f4f4;
   margin: 0;
-  padding: 0;
+  padding-top: 60px;
+  padding-bottom: 80px;
   min-height: 100vh;
 }
 
@@ -78,6 +79,8 @@ img {
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(2, 1fr);
+  height: calc(100vh - 140px);
 }
 
 .medal {
@@ -106,11 +109,28 @@ img {
 }
 
 .header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
   display: flex;
   justify-content: flex-end;
   align-items: center;
   gap: 0.5rem;
-  margin-bottom: 1rem;
+  padding: 0.5rem 1rem;
+  background: white;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  z-index: 1000;
+}
+.footer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  text-align: center;
+  padding: 0.5rem 1rem;
+  background: white;
+  box-shadow: 0 -2px 4px rgba(0,0,0,0.1);
 }
 
 .username {
@@ -139,7 +159,7 @@ img {
 }
 
 #rate-form {
-  margin-top: 1rem;
+  margin: 0;
 }
 
 @media (max-width: 600px) {
@@ -159,7 +179,7 @@ img {
     padding: 1rem;
   }
   #rate-form {
-    margin-top: 1rem;
+    margin: 0;
   }
 }
 
@@ -186,3 +206,23 @@ img {
   max-height: 50px;
   object-fit: contain;
 }
+
+@keyframes pulse {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+  100% { transform: scale(1); }
+}
+
+@keyframes bounce {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-10px); }
+}
+
+@keyframes rotate {
+  0% { transform: rotate(0); }
+  100% { transform: rotate(360deg); }
+}
+
+.anim-pulse { animation: pulse 3s ease-in-out infinite; }
+.anim-bounce { animation: bounce 2s ease-in-out infinite; }
+.anim-rotate { animation: rotate 8s linear infinite; }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -31,5 +31,8 @@
 {% endif %}
 {% block content %}{% endblock %}
 </div>
+<div class="footer">
+  {% block footer %}{% endblock %}
+</div>
 </body>
 </html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -10,22 +10,24 @@
   </div>
   {% endfor %}
 </div>
-<form id="rate-form" action="/rate" method="post">
-  <input type="hidden" id="order" name="order" />
-  <button id="submit-btn" type="submit" disabled>Submit</button>
-</form>
 {% else %}
 <p>No media files found</p>
 {% endif %}
 <script>
 let selected = [];
 const MAX_RANK = 4;
+const REQUIRED_SELECTIONS = MAX_RANK - 1;
+const animations = ['anim-pulse','anim-bounce','anim-rotate'];
+document.querySelectorAll('.media-preview').forEach(img => {
+  const cls = animations[Math.floor(Math.random()*animations.length)];
+  img.classList.add(cls);
+});
 function toggleRank(el){
   const file = el.dataset.file;
   const idx = selected.indexOf(file);
   if(idx >= 0){
     selected.splice(idx,1);
-  } else if(selected.length < MAX_RANK){
+  } else if(selected.length < REQUIRED_SELECTIONS){
     selected.push(file);
   }
   update();
@@ -45,14 +47,23 @@ function update(){
     if(!order.includes(c.dataset.file)) order.push(c.dataset.file);
   });
   document.getElementById('order').value = order.join(',');
-  document.getElementById('submit-btn').disabled = selected.length < MAX_RANK;
+  document.getElementById('submit-btn').disabled = selected.length < REQUIRED_SELECTIONS;
 }
 document.addEventListener('keydown', e => {
   const n = parseInt(e.key);
-  if(n >= 1 && n <= 4){
+  if(n >= 1 && n <= REQUIRED_SELECTIONS){
     const containers = document.querySelectorAll('.media-container');
     if(containers[n-1]) toggleRank(containers[n-1]);
   }
 });
 </script>
+{% endblock %}
+
+{% block footer %}
+{% if files %}
+<form id="rate-form" action="/rate" method="post">
+  <input type="hidden" id="order" name="order" />
+  <button id="submit-btn" type="submit" disabled>Submit</button>
+</form>
+{% endif %}
 {% endblock %}

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -92,4 +92,22 @@
   <li>{{ name }}: {{ count }}</li>
   {% endfor %}
 </ul>
+<h2>ELO Stats by Name</h2>
+{% if name_group_stats %}
+<table class="stats-table">
+  <tr><th>Name</th><th>Count</th><th>Min</th><th>Max</th><th>Avg</th><th>Stddev</th></tr>
+  {% for name, count, mn, mx, avg, std in name_group_stats %}
+  <tr>
+    <td>{{ name }}</td>
+    <td>{{ count }}</td>
+    <td>{{ '%.1f' % mn }}</td>
+    <td>{{ '%.1f' % mx }}</td>
+    <td>{{ '%.1f' % avg }}</td>
+    <td>{{ '%.1f' % std }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{% else %}
+<p>No ELO data yet.</p>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- compute ELO statistics grouped by filename base
- show the new stats table on the statistics page
- fix header and footer to screen edges and size media grid to quarter screen
- require only three selections when ranking and animate images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68771d0b45c483308cc199ecc84b9fb6