### PR TITLE
Improve stats and animations

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -87,7 +87,7 @@ img {
   position: absolute;
   top: 0.25rem;
   left: 0.25rem;
-  font-size: 2rem;
+  font-size: 5rem;
 }
 
 .last-ranked {
@@ -208,22 +208,15 @@ img {
   object-fit: contain;
 }
 
-@keyframes pulse {
-  0% { transform: scale(1); }
-  50% { transform: scale(1.05); }
-  100% { transform: scale(1); }
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
-@keyframes bounce {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-10px); }
+@keyframes fade-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
 }
 
-@keyframes rotate {
-  0% { transform: rotate(0); }
-  100% { transform: rotate(360deg); }
-}
-
-.anim-pulse { animation: pulse 3s ease-in-out infinite; }
-.anim-bounce { animation: bounce 2s ease-in-out infinite; }
-.anim-rotate { animation: rotate 8s linear infinite; }
+.fade-in { animation: fade-in 0.5s ease forwards; }
+.fade-out { animation: fade-out 0.5s ease forwards; }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -17,10 +17,36 @@
 let selected = [];
 const MAX_RANK = 4;
 const REQUIRED_SELECTIONS = MAX_RANK - 1;
-const animations = ['anim-pulse','anim-bounce','anim-rotate'];
-document.querySelectorAll('.media-preview').forEach(img => {
-  const cls = animations[Math.floor(Math.random()*animations.length)];
-  img.classList.add(cls);
+
+function adjustImage(img){
+  const wide = img.naturalWidth >= img.naturalHeight;
+  if(wide){
+    img.style.width = '100%';
+    img.style.height = 'auto';
+  } else {
+    img.style.width = 'auto';
+    img.style.height = '100%';
+  }
+}
+
+window.addEventListener('load', () => {
+  document.querySelectorAll('.media-preview').forEach(img => {
+    if(img.complete){
+      adjustImage(img);
+    } else {
+      img.onload = () => adjustImage(img);
+    }
+    img.classList.add('fade-in');
+  });
+
+  const form = document.getElementById('rate-form');
+  if(form){
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      document.querySelectorAll('.media-preview').forEach(img => img.classList.add('fade-out'));
+      setTimeout(() => form.submit(), 500);
+    });
+  }
 });
 function toggleRank(el){
   const file = el.dataset.file;

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -87,11 +87,6 @@
 
 <h2>Media Summary</h2>
 <p>Total files: {{ media_total }}</p>
-<ul>
-  {% for name, count in media_counts %}
-  <li>{{ name }}: {{ count }}</li>
-  {% endfor %}
-</ul>
 <h2>ELO Stats by Name</h2>
 {% if name_group_stats %}
 <table class="stats-table">


### PR DESCRIPTION
## Summary
- remove duplicate media list from the stats page
- enlarge ranking medals
- add fade animations and remove other image animations
- adjust image sizing with JavaScript

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68771fee9ca483308581dfa0189f2fad