### PR TITLE
Fix image scaling on ranking page

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -92,6 +92,8 @@ img {
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: repeat(2, 1fr);
   height: calc(100vh - 140px);
+  width: min(100vw, calc((100vh - 140px) * 4 / 3));
+  margin: 0 auto;
 }
 
 .medal {
@@ -181,6 +183,12 @@ img {
     border-radius: 0;
   }
   .admin-container {
+    width: 100%;
+  }
+  .media-grid {
+    grid-template-columns: 1fr;
+    grid-template-rows: none;
+    height: auto;
     width: 100%;
   }
   .media-preview {


### PR DESCRIPTION
## Summary
- keep ranking grid from getting too wide by limiting to viewport height
- switch to a single-column layout on small screens so images fit better

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68773066a55c83308252575ed14a4343