### PR TITLE
Fix keyboard shortcut for fourth item

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -59,13 +59,13 @@ function update(){
   document.getElementById('order').value = order.join(',');
   document.getElementById('submit-btn').disabled = selected.length < REQUIRED_SELECTIONS;
 }
-document.addEventListener('keydown', e => {
-  const n = parseInt(e.key);
-  if(n >= 1 && n <= REQUIRED_SELECTIONS){
-    const containers = document.querySelectorAll('.media-container');
-    if(containers[n-1]) toggleRank(containers[n-1]);
-  }
-});
+  document.addEventListener('keydown', e => {
+    const n = parseInt(e.key);
+    if(n >= 1 && n <= MAX_RANK){
+      const containers = document.querySelectorAll('.media-container');
+      if(containers[n-1]) toggleRank(containers[n-1]);
+    }
+  });
 </script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- allow the keyboard shortcut `4` to select the fourth media item

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877341be7848330bc9c6ce5ed09c796