### PR TITLE
Display ELO during ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ uvicorn app.main:app --reload
 The app serves files from a `/ranker-media` directory. You should mount a
 folder from the host into this location when running the container. A SQLite
 database is stored under `/config`, so that directory should also be mounted to
-retain user accounts and ratings. Users can register, log in and rate the
-displayed media from 1 to 5 using buttons or the keyboard. Media items are
-presented in order of least recently rated for each user, so once an item is
-scored a different file will be shown next. Each rating stores the time it was
-submitted so files can be sorted by when a user last rated them.
-The page also displays when the current media was last rated by the user. If it
-was rated today, the timestamp appears in green.
+retain user accounts and ranking history. Users can register, log in and order
+the displayed media using drag and drop or the keyboard. Each submission updates
+the global and personal ELO scores for the selected files. Media items are
+presented in order of least recently ranked for each user, so once an item is
+scored a different file will be shown next. Each ranking stores the time it was
+submitted so files can be sorted by when a user last interacted with them.
+The page also displays when the current media was last ranked by the user. If it
+was ranked today, the timestamp appears in green.
 
 Admin usernames can be supplied via the `ADMIN_USERS` environment variable as a
 comma separated list. When set, an authenticated admin can visit `/admin` to

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ranker
 
-Simple FastAPI application for rating media files.
+Simple FastAPI application for ranking media files.
 
 ## Development
 

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -120,6 +120,16 @@ img {
   color: green;
 }
 
+.elo-info {
+  position: absolute;
+  bottom: 0.25rem;
+  left: 0.25rem;
+  background: rgba(255, 255, 255, 0.7);
+  padding: 0 0.25rem;
+  font-size: 0.9rem;
+  border-radius: 2px;
+}
+
 .media-preview {
   width: 100%;
   height: 100%;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,9 +4,10 @@
 {% if files %}
 <div class="media-grid">
   {% for f in files %}
-  <div class="media-container" data-file="{{ f }}" onclick="toggleRank(this)">
-    <img class="media-preview" src="/media/{{ f }}" alt="{{ f }}" />
+  <div class="media-container" data-file="{{ f.filename }}" onclick="toggleRank(this)">
+    <img class="media-preview" src="/media/{{ f.filename }}" alt="{{ f.filename }}" />
     <span class="medal"></span>
+    <span class="elo-info">G {{ '%.1f' % f.global_elo }} | U {{ '%.1f' % f.user_elo if f.user_elo is not none else 'N/A' }}</span>
   </div>
   {% endfor %}
 </div>


### PR DESCRIPTION
## Summary
- show global and personal ELO on the ranking screen
- style ELO overlay
- fetch ELO values in the index route
- clarify README to describe ranking via ELO

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b5cfe7e0833097abe7711fa5eb16