### PR TITLE
Add Ollama embedding integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ comma separated list. When set, an authenticated admin can visit `/admin` to
 manage accounts and upload new media files. The upload form accepts multiple
 files so an admin can add several media items in one request.
 
+The admin panel also allows configuring an Ollama endpoint for generating image
+embeddings. Set the URL, optional API key and model name then click "Generate
+Embeddings" to create embeddings for all media files. Previously processed
+images are skipped.
+
 ## Docker
 
 Build and run with Docker:
@@ -51,7 +56,7 @@ GitHub Actions workflow builds the Docker image and publishes it to GHCR on each
 
 ## Database schema
 
-The application uses a SQLite database with three tables:
+The application uses a SQLite database with several tables:
 
 ```
 users(id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -76,6 +81,12 @@ user_media(username TEXT,
            elo REAL DEFAULT 1000,
            rating_count INTEGER DEFAULT 0,
            PRIMARY KEY(username, media_id))
+
+embeddings(id INTEGER PRIMARY KEY AUTOINCREMENT,
+           media_id INTEGER,
+           model TEXT,
+           embedding TEXT,
+           UNIQUE(media_id, model))
 ```
 
 Each row in `rankings` stores the four media IDs shown together in their ranked

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -36,6 +36,17 @@
 <form method="post" action="/admin/remove_duplicates" onsubmit="return confirm('Remove duplicate images?');">
   <button type="submit">Remove Duplicates</button>
 </form>
+<h2>Ollama Settings</h2>
+<form method="post" action="/admin/set_ollama">
+  <input type="text" name="url" placeholder="URL" value="{{ ollama_url }}" required />
+  <input type="text" name="api_key" placeholder="API Key" value="{{ ollama_api_key }}" />
+  <input type="text" name="model" placeholder="Model" value="{{ ollama_model }}" required />
+  <button type="submit">Save</button>
+</form>
+<h2>Generate Embeddings</h2>
+<form method="post" action="/admin/generate_embeddings" onsubmit="return confirm('Generate embeddings?');">
+  <button type="submit">Generate Embeddings</button>
+</form>
 <script>
 const form = document.getElementById('upload-form');
 form.addEventListener('submit', async (e) => {

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 Jinja2
 python-multipart
 Pillow
+requests


### PR DESCRIPTION
## Summary
- support generating image embeddings using Ollama
- store Ollama configuration and embedding data
- expose admin form for embedding generation
- handle animated GIFs by using the first frame
- add tests for embedding endpoints

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f91cfd9083308c0ef52fc7541696