### PR TITLE
Secure routes with signed session cookie

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Jinja2
 python-multipart
 Pillow
 requests
+itsdangerous

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -50,7 +50,7 @@ def test_register_and_login(client: TestClient):
     resp = client.post("/login", data={"username": "alice", "password": "secret"}, follow_redirects=False)
     assert resp.status_code == 303
     assert resp.headers["location"] == "/"
-    assert "username=alice" in resp.headers.get("set-cookie", "")
+    assert "session=" in resp.headers.get("set-cookie", "")
 
 
 def test_rating_and_stats(client: TestClient, tmp_path: Path):


### PR DESCRIPTION
## Summary
- add `itsdangerous` for signed cookie support
- store session token in a secure cookie
- update routes to read the new session cookie
- adjust tests for new cookie name

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687805713f0c8330a70ac0aa89b54f9d