### PR TITLE
Improve ranking UI and add dark mode

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -5,19 +5,33 @@
 :root {
   --header-height: 60px;
   --footer-height: 80px;
+  --bg-color: #f4f4f4;
+  --text-color: #000;
+  --card-bg: #fff;
+  --header-bg: #fff;
+  --footer-bg: #fff;
 }
 
 body {
   font-family: Arial, sans-serif;
-  background-color: #f4f4f4;
+  background-color: var(--bg-color);
+  color: var(--text-color);
   margin: 0;
   padding-top: var(--header-height);
   padding-bottom: var(--footer-height);
   min-height: 100vh;
 }
 
+body.dark-mode {
+  --bg-color: #222;
+  --text-color: #eee;
+  --card-bg: #333;
+  --header-bg: #333;
+  --footer-bg: #333;
+}
+
 .container {
-  background: white;
+  background: var(--card-bg);
   padding: 2rem;
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);
   border-radius: 4px;
@@ -30,8 +44,14 @@ body {
 /* Full width layout for the ranking page */
 .ranking-container {
   max-width: none;
-  padding-left: 0;
-  padding-right: 0;
+  padding: 0;
+  background: none;
+  box-shadow: none;
+  border-radius: 0;
+  min-height: calc(100vh - var(--header-height) - var(--footer-height));
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .admin-container {
@@ -87,13 +107,14 @@ img {
   display: flex;
   justify-content: center;
   align-items: center;
+  border: 1px solid #ccc;
   aspect-ratio: 4 / 3;
   width: 100%;
 }
 
 .media-grid {
   display: grid;
-  gap: 1rem;
+  gap: 0.5rem;
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: repeat(2, 1fr);
   width: min(100vw, calc((100vh - var(--header-height) - var(--footer-height)) * 4 / 3));
@@ -136,7 +157,7 @@ img {
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
-  background: white;
+  background: var(--header-bg);
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
   z-index: 1000;
 }
@@ -147,7 +168,7 @@ img {
   right: 0;
   text-align: center;
   padding: 0.5rem 1rem;
-  background: white;
+  background: var(--footer-bg);
   box-shadow: 0 -2px 4px rgba(0,0,0,0.1);
 }
 
@@ -201,8 +222,9 @@ img {
     height: 100%;
   }
   #rate-form button {
-    font-size: 1.5rem;
-    padding: 1rem;
+    font-size: 2rem;
+    padding: 1.25rem 1.5rem;
+    width: 100%;
   }
   #rate-form {
     margin: 0;
@@ -227,10 +249,24 @@ img {
   background-color: #f0f0f0;
 }
 
+.stats-table th.sortable {
+  cursor: pointer;
+  position: relative;
+}
+
+.stats-table th.sortable .sort-arrow {
+  margin-left: 0.25rem;
+}
+
+.stats-table th[data-dir] {
+  background-color: #e0e0e0;
+}
+
 .thumbnail {
   max-width: 75px;
   max-height: 75px;
   object-fit: contain;
+  margin: 0;
 }
 
 @keyframes fade-in {

--- a/app/static/table-sort.js
+++ b/app/static/table-sort.js
@@ -2,7 +2,8 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.stats-table').forEach(table => {
     const ths = table.querySelectorAll('th');
     ths.forEach((th, index) => {
-      th.style.cursor = 'pointer';
+      th.classList.add('sortable');
+      th.insertAdjacentHTML('beforeend', '<span class="sort-arrow"></span>');
       th.addEventListener('click', () => sortTable(table, index, th.dataset.type));
     });
   });
@@ -11,9 +12,11 @@ document.addEventListener('DOMContentLoaded', () => {
 function sortTable(table, col, type) {
   const tbody = table.tBodies[0];
   const rows = Array.from(tbody.querySelectorAll('tr'));
-  const th = table.querySelectorAll('th')[col];
+  const ths = table.querySelectorAll('th');
+  const th = ths[col];
   const dir = th.dataset.dir === 'asc' ? 'desc' : 'asc';
   th.dataset.dir = dir;
+  ths.forEach((header,i) => { if(i !== col) header.removeAttribute('data-dir'); });
   rows.sort((a, b) => {
     let x = a.children[col].textContent.trim();
     let y = b.children[col].textContent.trim();
@@ -26,4 +29,11 @@ function sortTable(table, col, type) {
     return 0;
   });
   rows.forEach(r => tbody.appendChild(r));
+  ths.forEach(header => {
+    const arrow = header.querySelector('.sort-arrow');
+    if(!arrow) return;
+    if(header.dataset.dir === 'asc') arrow.textContent = '▲';
+    else if(header.dataset.dir === 'desc') arrow.textContent = '▼';
+    else arrow.textContent = '';
+  });
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -6,9 +6,8 @@
 </head>
 <body{% if body_class %} class="{{ body_class }}"{% endif %}>
 <div class="container{% if container_class %} {{ container_class }}{% endif %}">
-{% if username %}
   <div class="header">
-    <span class="username">{{ username }}</span>
+    {% if username %}<span class="username">{{ username }}</span>{% endif %}
     {% if show_admin %}
     <form method="get" action="/admin">
       <button type="submit">Admin</button>
@@ -24,15 +23,38 @@
       <button type="submit">Back to Ranking</button>
     </form>
     {% endif %}
+    {% if username %}
     <form method="get" action="/logout">
       <button type="submit">Logout</button>
     </form>
+    {% endif %}
+    <button id="theme-toggle" type="button">🌙</button>
   </div>
-{% endif %}
 {% block content %}{% endblock %}
 </div>
 <div class="footer">
   {% block footer %}{% endblock %}
 </div>
+<script>
+function applyTheme(mode){
+  if(mode === 'dark'){
+    document.body.classList.add('dark-mode');
+    document.getElementById('theme-toggle').textContent = '☀️';
+  } else {
+    document.body.classList.remove('dark-mode');
+    document.getElementById('theme-toggle').textContent = '🌙';
+  }
+}
+
+const storedTheme = localStorage.getItem('theme');
+applyTheme(storedTheme);
+
+document.getElementById('theme-toggle').addEventListener('click', () => {
+  const dark = document.body.classList.contains('dark-mode');
+  const mode = dark ? 'light' : 'dark';
+  localStorage.setItem('theme', mode);
+  applyTheme(mode);
+});
+</script>
 </body>
 </html>

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -4,7 +4,10 @@
 <h2>Global ELO Ranking</h2>
 {% if elo_ranking %}
 <table class="stats-table">
-  <tr><th data-type="number">#</th><th>Preview</th><th data-type="string">Media</th><th data-type="number">ELO</th><th data-type="number">Ratings</th></tr>
+  <thead>
+    <tr><th data-type="number">#</th><th>Preview</th><th data-type="string">Media</th><th data-type="number">ELO</th><th data-type="number">Ratings</th></tr>
+  </thead>
+  <tbody>
   {% for media, elo, cnt in elo_ranking %}
   <tr>
     <td>{{ loop.index }}</td>
@@ -14,6 +17,7 @@
     <td>{{ cnt }}</td>
   </tr>
   {% endfor %}
+  </tbody>
 </table>
 {% else %}
 <p>No rankings yet.</p>
@@ -21,7 +25,10 @@
 <h2>Your Highest Rated Media</h2>
 {% if user_highest %}
 <table class="stats-table">
-  <tr><th>Preview</th><th data-type="string">Media</th><th data-type="number">Your ELO</th><th data-type="number">Global ELO</th><th data-type="number">Your #</th><th data-type="number">Global #</th></tr>
+  <thead>
+    <tr><th>Preview</th><th data-type="string">Media</th><th data-type="number">Your ELO</th><th data-type="number">Global ELO</th><th data-type="number">You Ranked # Times</th><th data-type="number">Globally Ranked # Times</th></tr>
+  </thead>
+  <tbody>
   {% for media, user_score, global_score, user_cnt, global_cnt in user_highest %}
   <tr>
     <td><img class="thumbnail" src="/media/{{ media }}" alt="{{ media }}" /></td>
@@ -32,6 +39,7 @@
     <td>{{ global_cnt }}</td>
   </tr>
   {% endfor %}
+  </tbody>
 </table>
 {% else %}
 <p>No ratings yet.</p>
@@ -40,7 +48,10 @@
 <h2>Global Highest Rated Media</h2>
 {% if global_highest %}
 <table class="stats-table">
-  <tr><th>Preview</th><th data-type="string">Media</th><th data-type="number">Global ELO</th><th data-type="number">Your ELO</th><th data-type="number">Global #</th><th data-type="number">Your #</th></tr>
+  <thead>
+    <tr><th>Preview</th><th data-type="string">Media</th><th data-type="number">Global ELO</th><th data-type="number">Your ELO</th><th data-type="number">Globally Ranked # Times</th><th data-type="number">You Ranked # Times</th></tr>
+  </thead>
+  <tbody>
   {% for media, global_score, user_score, global_cnt, user_cnt in global_highest %}
   <tr>
     <td><img class="thumbnail" src="/media/{{ media }}" alt="{{ media }}" /></td>
@@ -51,6 +62,7 @@
     <td>{{ user_cnt }}</td>
   </tr>
   {% endfor %}
+  </tbody>
 </table>
 {% else %}
 <p>No ratings yet.</p>
@@ -59,7 +71,10 @@
 <h2>Your Lowest Rated Media</h2>
 {% if user_lowest %}
 <table class="stats-table">
-  <tr><th>Preview</th><th data-type="string">Media</th><th data-type="number">Your ELO</th><th data-type="number">Global ELO</th><th data-type="number">Your #</th><th data-type="number">Global #</th></tr>
+  <thead>
+    <tr><th>Preview</th><th data-type="string">Media</th><th data-type="number">Your ELO</th><th data-type="number">Global ELO</th><th data-type="number">You Ranked # Times</th><th data-type="number">Globally Ranked # Times</th></tr>
+  </thead>
+  <tbody>
   {% for media, user_score, global_score, user_cnt, global_cnt in user_lowest %}
   <tr>
     <td><img class="thumbnail" src="/media/{{ media }}" alt="{{ media }}" /></td>
@@ -70,6 +85,7 @@
     <td>{{ global_cnt }}</td>
   </tr>
   {% endfor %}
+  </tbody>
 </table>
 {% else %}
 <p>No ratings yet.</p>
@@ -78,7 +94,10 @@
 <h2>Global Lowest Rated Media</h2>
 {% if global_lowest %}
 <table class="stats-table">
-  <tr><th>Preview</th><th data-type="string">Media</th><th data-type="number">Global ELO</th><th data-type="number">Your ELO</th><th data-type="number">Global #</th><th data-type="number">Your #</th></tr>
+  <thead>
+    <tr><th>Preview</th><th data-type="string">Media</th><th data-type="number">Global ELO</th><th data-type="number">Your ELO</th><th data-type="number">Globally Ranked # Times</th><th data-type="number">You Ranked # Times</th></tr>
+  </thead>
+  <tbody>
   {% for media, global_score, user_score, global_cnt, user_cnt in global_lowest %}
   <tr>
     <td><img class="thumbnail" src="/media/{{ media }}" alt="{{ media }}" /></td>
@@ -89,6 +108,7 @@
     <td>{{ user_cnt }}</td>
   </tr>
   {% endfor %}
+  </tbody>
 </table>
 {% else %}
 <p>No ratings yet.</p>
@@ -100,7 +120,10 @@
 <h2>ELO Stats by Name</h2>
 {% if name_group_stats %}
 <table class="stats-table">
-  <tr><th data-type="string">Name</th><th data-type="number">Files</th><th data-type="number">Ratings</th><th data-type="number">Min</th><th data-type="number">Max</th><th data-type="number">Avg</th><th data-type="number">Stddev</th></tr>
+  <thead>
+    <tr><th data-type="string">Name</th><th data-type="number">Files</th><th data-type="number">Ratings</th><th data-type="number">Min</th><th data-type="number">Max</th><th data-type="number">Avg</th><th data-type="number">Stddev</th></tr>
+  </thead>
+  <tbody>
   {% for name, count, ratings, mn, mx, avg, std in name_group_stats %}
   <tr>
     <td>{{ name }}</td>
@@ -112,6 +135,7 @@
     <td>{{ '%.1f' % std }}</td>
   </tr>
   {% endfor %}
+  </tbody>
 </table>
 {% else %}
 <p>No ELO data yet.</p>


### PR DESCRIPTION
## Summary
- add dark mode support with persistent toggle
- revamp ranking layout and tables
- tweak mobile button sizing and grid spacing
- show arrows for sortable tables
- rename ranking count columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68784eb4075c8330820c875d06c1bac3